### PR TITLE
Modify deployment to use a SSH deploy key instead of an access token

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,5 +22,5 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3
         name: Deploy to GitHub Pages
         with:
-          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./web


### PR DESCRIPTION
This will now use a SSH key pair, with restricted write access to this repository only.

You can create this key pair by following this instructions:

https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key

I hope this solves your concerns and serves as a proper solution.